### PR TITLE
Update query.go

### DIFF
--- a/query.go
+++ b/query.go
@@ -6,7 +6,7 @@ func withContinue(token string) queryParamsFunc {
 	if len(token) == 0 {
 		return noOp
 	}
-	return withParam("continue", token)
+	return withParam("ContinuationToken", token)
 }
 
 func withParam(name, value string) queryParamsFunc {


### PR DESCRIPTION
According to the API reference, `ContinuationToken` query parameter is to be used for paging. Not `continue`. https://learn.microsoft.com/en-us/rest/api/servicefabric/sfclient-api-getapplicationinfolist#continuationtoken